### PR TITLE
Move Elysia app to /e route, run astro app on root

### DIFF
--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-isaacscript": "^3.5.7",
     "eslint-plugin-prettier": "^5.0.1",
-    "pino": "^8.16.2",
     "prettier": "^3.1.0",
     "prettier-plugin-tailwindcss": "^0.5.7",
     "rescript": "11.0.0-rc.5",
@@ -64,6 +63,7 @@
     "drizzle-typebox": "^0.1.1",
     "elysia": "^0.7.29",
     "lucia": "^2.7.4",
+    "pino": "^8.16.2",
     "pino-pretty": "^10.2.3",
     "zod": "^3.22.4"
   },

--- a/apps/be/src/components/base.tsx
+++ b/apps/be/src/components/base.tsx
@@ -18,7 +18,7 @@ export const BaseHtml = ({ children }: PropsWithChildren) => (
         rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/@unocss/reset/tailwind.min.css"
       />
-      <link rel="stylesheet" href="/public/dist/unocss.css" />
+      <link rel="stylesheet" href="/e/public/dist/unocss.css" />
       <script>{safeScript}</script>
     </head>
     <body hx-boost="true" class="h-screen">

--- a/apps/be/src/components/tweets.tsx
+++ b/apps/be/src/components/tweets.tsx
@@ -30,7 +30,7 @@ export function TweetCard({
         <span class="text-sm text-gray-500">{createdAt.toLocaleString()}</span>
         <button
           class="i-lucide-x text-lg text-red-500"
-          hx-delete={`/api/tweets/${id}`}
+          hx-delete={`/e/api/tweets/${id}`}
           hx-target={`#tweet-${id}`}
           hx-swap="outerHTML"
           hx-target-4xx="next #tweetDeleteError"
@@ -55,6 +55,8 @@ export async function InitialTweetList() {
     },
   })
 
+  console.log(tweetData)
+
   const lastTweetTime = tweetData[tweetData.length - 1]?.createdAt
 
   return (
@@ -64,7 +66,7 @@ export async function InitialTweetList() {
           <TweetCard {...tweet} />
         ))}
         <div
-          hx-get={`/api/tweets?after=${lastTweetTime?.toISOString()}`}
+          hx-get={`/e/api/tweets/?after=${lastTweetTime?.toISOString()}`}
           hx-swap="beforeend"
           hx-target="#tweetList"
           hx-trigger="revealed"
@@ -97,7 +99,7 @@ export async function AdditionalTweetList({ after }: { after: Date }) {
       ))}
       {lastTweetTime && (
         <div
-          hx-get={`/api/tweets?after=${lastTweetTime.toISOString()}`}
+          hx-get={`/e/api/tweets/?after=${lastTweetTime.toISOString()}`}
           hx-swap="beforeend"
           hx-target="#tweetList"
           hx-trigger="revealed"
@@ -112,7 +114,7 @@ export function TweetCreationForm() {
     <div class="rounded-lg border p-4 shadow-md">
       <h2 class="mb-4 text-xl font-bold">Create a new Tweet</h2>
       <form
-        hx-post="/api/tweets"
+        hx-post="/e/api/tweets"
         hx-swap="afterbegin"
         hx-target="#tweetList"
         _="on submit target.reset()"

--- a/apps/be/src/controllers/tweets.tsx
+++ b/apps/be/src/controllers/tweets.tsx
@@ -50,7 +50,6 @@ export const tweetsController = new Elysia({
       if (!tweet) {
         throw new Error("Failed to create tweet")
       }
-
       return (
         <TweetCard
           content={tweet.content}
@@ -107,6 +106,49 @@ export const tweetsController = new Elysia({
       }
 
       await db.delete(tweets).where(eq(tweets.id, tweetId))
+    },
+    {
+      params: t.Object({
+        tweetId: t.Numeric(),
+      }),
+    },
+  ).get(
+    "/:tweetId",
+    async ({ session, db, params: { tweetId }, set, log }) => {
+      if (!session) {
+        set.status = "Unauthorized"
+        return (
+          'HELLLOOOOO'
+        )
+      }
+      console.log(tweetId)
+
+      const [tweet] = await db
+        .select()
+        .from(tweets)
+        .where(eq(tweets.id, tweetId))
+
+      log.debug(tweet)
+
+      if (!tweet) {
+        set.status = "Not Found"
+        return (
+          <div id="tweetDeleteError" class="text-center text-red-500">
+            Tweet not found
+          </div>
+        )
+      }
+
+      if (tweet.authorId !== session.user.userId) {
+        set.status = "Unauthorized"
+        return (
+          <div id="tweetDeleteError" class="text-center text-red-500">
+            Unauthorized
+          </div>
+        )
+      }
+
+      return tweet;
     },
     {
       params: t.Object({

--- a/apps/be/src/main.ts
+++ b/apps/be/src/main.ts
@@ -7,24 +7,30 @@ import { config } from "./config"
 import { api } from "./controllers/*"
 import { pages } from "./pages/*"
 
-const app = new Elysia()
-  // .use(swagger())
-  // @ts-expect-error idc
-  .use(staticPlugin())
-  .use(api)
-  .use(pages)
-  .onStart(({ log }) => {
-    if (config.env.NODE_ENV === "development") {
-      void fetch("http://localhost:3001/restart")
-      // log.debug("🦊 Triggering Live Reload");
-      console.log("🦊 Triggering Live Reload")
-    }
+//@ts-ignore
+const app =
+  new Elysia({
+    prefix: '/e',
   })
-  .onError(({ code, error, request, log }) => {
-    // log.error(` ${request.method} ${request.url}`, code, error);
-    console.error(error)
-  })
-  .listen(3000)
+    .use(
+      //@ts-expect-error
+      staticPlugin({})
+    )
+    // .use(swagger())
+    .use(api)
+    .use(pages)
+    .onStart(() => {
+      if (config.env.NODE_ENV === "development") {
+        void fetch("http://localhost:3001/restart")
+        // log.debug("🦊 Triggering Live Reload");
+        console.log("🦊 Triggering Live Reload")
+      }
+    })
+    .onError(({ code, error, request }) => {
+      // log.error(` ${request.method} ${request.url}`, code, error);
+      console.error(error)
+    })
+    .listen(3000)
 
 export type App = typeof app
 

--- a/apps/be/src/pages/(auth)/signin.tsx
+++ b/apps/be/src/pages/(auth)/signin.tsx
@@ -31,7 +31,7 @@ export const login = new Elysia()
             </a>
           </div>
           <form
-            hx-post="/api/auth/signInOrUp"
+            hx-post="/e/api/auth/signInOrUp"
             hx-swap="innerHTML"
             hx-target-4xx="#errorMessage"
             class="w-96 rounded-lg bg-white p-8 shadow-md"
@@ -85,7 +85,7 @@ export const login = new Elysia()
               </button>
               <a
                 hx-boost="false"
-                href="/login/github"
+                href="/e/login/github"
                 class="display-block rounded-lg bg-gray-800 p-2 text-center text-white transition duration-200 hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-opacity-50"
               >
                 Sign In with Github
@@ -145,6 +145,7 @@ export const login = new Elysia()
           attributes: {},
         })
         const sessionCookie = auth.createSessionCookie(session)
+        console.log(sessionCookie)
         // redirect to profile page
         return new Response(null, {
           headers: {

--- a/apps/be/src/pages/index.tsx
+++ b/apps/be/src/pages/index.tsx
@@ -23,7 +23,7 @@ export const index = new Elysia()
                 Hi! {session.user.handle}
               </h1>
               <button
-                hx-post="/api/auth/signout"
+                hx-post="/e/api/auth/signout"
                 class="mt-4 rounded-lg bg-blue-500 px-4 py-2 text-white transition duration-200 hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-50"
               >
                 Sign Out
@@ -32,7 +32,7 @@ export const index = new Elysia()
             </>
           ) : (
             <a
-              href="/login"
+              href="/e/login"
               hx-boost="false"
               class="mt-4 rounded-lg bg-blue-500 px-4 py-2 text-white transition duration-200 hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-50"
             >

--- a/apps/be/src/types/htmx.d.ts
+++ b/apps/be/src/types/htmx.d.ts
@@ -28,11 +28,11 @@ type RouterPattern<T extends string> =
     ? `${Start}${string}`
     : T
 
-type StartsWithApi<T extends string> = T extends `${"/api"}${infer Rest}`
+type StartsWithApi<T extends string> = T extends `${"/e/api"}${infer Rest}`
   ? T
   : never
 
-type DoesntStartWithApi<T extends string> = T extends `${"/api"}${infer Rest}`
+type DoesntStartWithApi<T extends string> = T extends `${"/e/api"}${infer Rest}`
   ? never
   : T
 

--- a/apps/be/uno.config.ts
+++ b/apps/be/uno.config.ts
@@ -10,4 +10,4 @@ export default defineConfig({
   },
   presets: [presetWind(), presetIcons(), presetWebFonts()],
   transformers: [transformerVariantGroup()],
-})
+}) as any

--- a/apps/web/src/components/solid/SolidCounter.tsx
+++ b/apps/web/src/components/solid/SolidCounter.tsx
@@ -1,11 +1,12 @@
-import { createSignal } from 'solid-js'
+import { createResource, createSignal } from 'solid-js'
 
 /** A counter written with Solid */
 export default function SolidCounter({ children }) {
 	const [count, setCount] = createSignal(0)
 	const add = () => setCount(count() + 1)
 	const subtract = () => setCount(count() - 1)
-
+	const [data] = createResource({ tweetId: 2 }, getTweets);
+	console.log(data);
 	return (
 		<>
 			<div id="solid" class="counter">
@@ -17,3 +18,14 @@ export default function SolidCounter({ children }) {
 		</>
 	)
 }
+
+export async function getTweets({ tweetId }: { tweetId: number }) {
+	// if (query.trim() === "") return [];
+	const response = await fetch(
+	  `/e/api/tweets/${tweetId}`
+	);
+	const results = await response.json();
+	return results;
+  }
+  
+  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: latest
         version: 1.10.16
 
-  apps/bun:
+  apps/be:
     dependencies:
       '@bogeychan/elysia-logger':
         specifier: ^0.0.13
@@ -71,6 +71,9 @@ importers:
       lucia:
         specifier: ^2.7.4
         version: 2.7.4
+      pino:
+        specifier: ^8.16.2
+        version: 8.16.2
       pino-pretty:
         specifier: ^10.2.3
         version: 10.2.3
@@ -129,9 +132,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.0.1
         version: 5.0.1(@types/eslint@8.44.7)(eslint-config-prettier@9.0.0)(eslint@8.54.0)(prettier@3.1.0)
-      pino:
-        specifier: ^8.16.2
-        version: 8.16.2
       prettier:
         specifier: ^3.1.0
         version: 3.1.0
@@ -2259,6 +2259,7 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.11.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2512,6 +2513,7 @@ packages:
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+    dev: false
 
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
@@ -2684,6 +2686,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -4037,6 +4040,7 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -4045,6 +4049,7 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -4161,6 +4166,7 @@ packages:
   /fast-redact@3.3.0:
     resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -6033,6 +6039,7 @@ packages:
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+    dev: false
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -6225,6 +6232,7 @@ packages:
     dependencies:
       readable-stream: 4.4.2
       split2: 4.2.0
+    dev: false
 
   /pino-pretty@10.2.3:
     resolution: {integrity: sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==}
@@ -6248,6 +6256,7 @@ packages:
 
   /pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+    dev: false
 
   /pino@8.16.2:
     resolution: {integrity: sha512-2advCDGVEvkKu9TTVSa/kWW7Z3htI/sBKEZpqiHk6ive0i/7f5b1rsU8jn0aimxqfnSz5bj/nOYkwhBUn5xxvg==}
@@ -6264,6 +6273,7 @@ packages:
       safe-stable-stringify: 2.4.3
       sonic-boom: 3.7.0
       thread-stream: 2.4.1
+    dev: false
 
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -6441,10 +6451,12 @@ packages:
 
   /process-warning@2.3.1:
     resolution: {integrity: sha512-JjBvFEn7MwFbzUDa2SRtKJSsyO0LlER4V/FmwLMhBlXNbGgGxdyFCxIdMDLerWUycsVUyaoM9QFLvppFy4IWaQ==}
+    dev: false
 
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+    dev: false
 
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -6488,6 +6500,7 @@ packages:
 
   /quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    dev: false
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -6545,6 +6558,7 @@ packages:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
+    dev: false
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -6555,6 +6569,7 @@ packages:
   /real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+    dev: false
 
   /reflect.getprototypeof@1.0.4:
     resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
@@ -6821,6 +6836,7 @@ packages:
   /safe-stable-stringify@2.4.3:
     resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
+    dev: false
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -7000,6 +7016,7 @@ packages:
     resolution: {integrity: sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==}
     dependencies:
       atomic-sleep: 1.0.0
+    dev: false
 
   /sort-object-keys@1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
@@ -7067,6 +7084,7 @@ packages:
   /split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -7311,6 +7329,7 @@ packages:
     resolution: {integrity: sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==}
     dependencies:
       real-require: 0.2.0
+    dev: false
 
   /timers-ext@0.1.7:
     resolution: {integrity: sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==}


### PR DESCRIPTION
- Couldn't go ahead with Elysia running on root domain and astro on /a, Vite local server doesn't support this. Given that I run both apps together even on localhost, astro was not able to find any static files.
- Moves elysia app base path to "/e", this way nginx can route everything on "e" to the elysia backend app (which also serves a couple frontend pages, the ones related to authentication)
- This means the root domain will be served by astro, which is an overall better choice anyway!
- Also includes some fixes to types.